### PR TITLE
return the results part of the response from submit()

### DIFF
--- a/prismic/api.py
+++ b/prismic/api.py
@@ -150,7 +150,7 @@ class SearchForm(object):
         request.set_get_params(self.data)
         request.set_access_token(self.access_token)
 
-        return [Document(doc) for doc in request.get_json()]
+        return [Document(doc) for doc in request.get_json()['results']]
 
 
 class Document(object):


### PR DESCRIPTION
Here you go - I haven't added a unit test for this fix because tests.test_prismic.ApiIntegrationTestCase was already failing. It passes with this change :)
