### PR TITLE
Added missing class type for Embed fragments in from_json method.

### DIFF
--- a/prismic/fragments.py
+++ b/prismic/fragments.py
@@ -30,7 +30,8 @@ class Fragment(object):
                 "Number":         Fragment.Number,
                 "Date":           Fragment.Date,
                 "StructuredText": structured_text.StructuredText,
-                "Link.document":  Fragment.DocumentLink
+                "Link.document":  Fragment.DocumentLink,
+                "Embed":          Fragment.Embed
             }
 
         fragment_type = data.get("type")


### PR DESCRIPTION
When the Fragment is of type "Embed", after making a query no fragment is returned in the object. Instead, we got a warning "fragment_type not found: Embed".

Just need to add the Embed type in the _types object and match it with the Fragment.Embed class.
