### PR TITLE
tweak to prevent ShelveCache from being initialized when not needed

### DIFF
--- a/prismic/api.py
+++ b/prismic/api.py
@@ -23,8 +23,9 @@ from .cache import ShelveCache
 
 log = logging.getLogger(__name__)
 
+DEFAULT_CACHE = object()
 
-def get(url, access_token=None, cache=ShelveCache()):
+def get(url, access_token=None, cache=DEFAULT_CACHE):
     """Fetches the prismic api JSON.
     Returns :class:`Api <Api>` object.
 
@@ -34,12 +35,14 @@ def get(url, access_token=None, cache=ShelveCache()):
     return Api(_get_json(url, access_token=access_token, cache=cache), access_token, cache)
 
 
-def _get_json(url, params=dict(), access_token=None, cache=ShelveCache()):
+def _get_json(url, params=dict(), access_token=None, cache=DEFAULT_CACHE):
     full_params = params.copy()
     if access_token is not None:
         full_params["access_token"] = access_token
     full_url = url if len(full_params) == 0 else (url + "?" + urllib.urlencode(full_params, doseq=1))
     cached = cache.get(full_url)
+    if cache == DEFAULT_CACHE:
+        cache = ShelveCache()
     if cached is not None:
         return cached
     try:


### PR DESCRIPTION
Currently ShelveCache is initialized even when a different cache is specified.  This causes issues if we have not configured the "cache" directory properly.  This pull request changes the module to only initialize ShelveCache when it is actually needed.