### PR TITLE
Raise an AttributeError in Document.__getattr__

### DIFF
--- a/prismic/api.py
+++ b/prismic/api.py
@@ -419,7 +419,9 @@ class Document(Fragment.WithFragments):
         })
 
     def __getattr__(self, name):
-        return self._data.get(name)
+        if name.startswith('__'):
+            raise AttributeError
+        return self._data.get(name, None)
 
     @property
     def slug(self):


### PR DESCRIPTION
Raise an AttributeError in Document.__getattr__.

pickle does'nt not work without that (and django.core.cache can't work also, using pickle)

Refs: http://stackoverflow.com/questions/6415951/python-pickle-crash-when-trying-to-return-default-value-in-getattr