### PR TITLE
Custom request handlers feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ You can pass a Memcached client to the `prismic.get` call:
 By duck typing you can pass any object that implement the `set` and `get` methods (see the `NoCache` object for the methods
 to implement).
 
+#### Using a Custom Request Handler
+
+By default, the kit will use a request handler based on the popular package [requests](http://python-requests.org). If you, for some reason, wants to use a custom request handler,
+ such as URLFetch (if you use Google AppEngine), for example. You can pass a function to the `prismic.get` call, this way:
+
+ ```python
+ >>> import prismic
+ >>> import urllib2
+ >>> def custom_request_handler(full_url):
+ ...     r = urllib2.urlopen(full_url)
+ ...     return r.getcode(), r.read(), r.info()
+ ...
+ >>> api = prismic.get("http://your-lesbonneschoses.prismic.io/api", "access_token", request_handler=custom_request_handler)
+ ```
+
+By duck typing you can pass any function that receives a URL and return a tuple containing status code, content and the headers of the response.
+
 ### Changelog
 
 Need to see what changed, or to upgrade your kit? We keep our changelog on [this repository's "Releases" tab](https://github.com/prismicio/python-kit/releases).

--- a/prismic/connection.py
+++ b/prismic/connection.py
@@ -23,12 +23,13 @@ from requests.exceptions import InvalidSchema
 from .exceptions import (InvalidTokenError, AuthorizationNeededError,
                          HTTPError, InvalidURLError)
 from .cache import ShelveCache
+from . import __version__ as prismic_version
 
 def get_using_requests(full_url):
     request = requests.get(full_url, headers={
         "Accept": "application/json",
         "User-Agent": "Prismic-python-kit/%s Python/%s" % (
-            pkg_resources.require("prismic")[0].version,
+            prismic_version,
             platform.python_version()
         )
     })

--- a/prismic/connection.py
+++ b/prismic/connection.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+"""
+prismic.connection
+~~~~~~~~~~~
+
+This module implements the Prismic Connection handlers.
+
+"""
+
+try:  # 2.7
+    import urllib.parse as urlparse
+except ImportError:  # 3.x
+    import urllib as urlparse
+
+import requests
+import json
+import re
+import platform
+import pkg_resources
+from collections import OrderedDict
+from requests.exceptions import InvalidSchema
+from .exceptions import (InvalidTokenError, AuthorizationNeededError,
+                         HTTPError, InvalidURLError)
+from .cache import ShelveCache
+
+def get_using_requests(full_url):
+    request = requests.get(full_url, headers={
+        "Accept": "application/json",
+        "User-Agent": "Prismic-python-kit/%s Python/%s" % (
+            pkg_resources.require("prismic")[0].version,
+            platform.python_version()
+        )
+    })
+    return request.status_code, request.text, request.headers
+
+def get_json(url, params=None, access_token=None, cache=None, ttl=None, request_handler=None):
+    full_params = dict() if params is None else params.copy()
+    if cache is None:
+        cache = ShelveCache(re.sub(r'/\\', '', url.split('/')[2]))
+    if request_handler is None:
+        request_handler = get_using_requests
+    if access_token is not None:
+        full_params["access_token"] = access_token
+    full_url = url if len(full_params) == 0 else (url + "?" + urlparse.urlencode(full_params, doseq=1))
+    cached = cache.get(full_url)
+    if cached is not None:
+        return cached
+    try:
+        status_code, text_result, headers = request_handler(full_url)
+        if status_code == 200:
+            json_result = json.loads(text_result, object_pairs_hook=OrderedDict)
+            expire = ttl or get_max_age(headers)
+            if expire is not None:
+                cache.set(full_url, json_result, expire)
+            return json_result
+        elif status_code == 401:
+            if len(access_token) == 0:
+                raise AuthorizationNeededError()
+            else:
+                raise InvalidTokenError()
+        else:
+            raise HTTPError(status_code, str(text_result))
+    except InvalidSchema as e:
+        raise InvalidURLError(e)
+
+
+def get_max_age(headers):
+    expire_header = headers["Cache-Control"]
+    if expire_header is not None:
+        m = re.match("max-age=(\d+)", expire_header)
+        if m:
+            return int(m.group(1))
+    return None

--- a/tests/test_prismic.py
+++ b/tests/test_prismic.py
@@ -37,7 +37,7 @@ class PrismicTestCase(unittest.TestCase):
         self.fixture_spans_labels = json.loads(fixture_spans_labels)
         self.fixture_custom_html = json.loads(fixture_custom_html)
 
-        self.api = prismic.Api(self.fixture_api, self.token, ShelveCache("prismictest"))
+        self.api = prismic.Api(self.fixture_api, self.token, ShelveCache("prismictest"), None)
 
     def tearDown(self):
         """Teardown."""


### PR DESCRIPTION
Hello.

This PR adds custom request handlers support to the package and remove HTTPS support by default, as the title already specifies, but okay.

The custom request handlers allow anyone to use anything (synchronous) they want to make the request. In my case, for example, I cannot use this python-kit because `requests` does not really likes AppEngine, for example. I think that other use cases is possible, but the fact that `requests` does not works on AppEngine is sufficient for me. =)

Other question is that I removed HTTPS support by default. There's three reasons for that:

1) prismic.io works natively without HTTPS. And not everyone needs HTTPS support by default;
2) HTTPS support needs a GCC compiler to compile the SSL support needed by the library;
3) AppEngine doesn't like C compiled modules; =P

Instead, I added the HTTPS support as an optional requeriment, which can be installed using something like `pip install prismic[https_support]`. And updated the tests to use HTTP instead of HTTPS, obviously. 

Oh, and the README is updated according to the these updates, too. =)

Well, that's everything. I expect that you may like the changes. (maybe you call me crazy by removing HTTPS support, but....seems good for me (as prismic.io really can work without HTTPS))

And...sorry for my (possible) poor english. 

That's it.