### PR TITLE
Fix bug with fulltext predicate where document is not queriable

### DIFF
--- a/prismic/api.py
+++ b/prismic/api.py
@@ -160,7 +160,7 @@ class SearchForm(object):
     @staticmethod
     def _serialize(field):
         if isinstance(field, string_types):
-            if field.startswith('my.') or field.startswith('document.'):
+            if field.startswith('my.') or field.startswith('document.') or field == 'document':
                 return field
             else:
                 return '"' + field + '"'

--- a/prismic/connection.py
+++ b/prismic/connection.py
@@ -17,7 +17,6 @@ import requests
 import json
 import re
 import platform
-import pkg_resources
 from collections import OrderedDict
 from requests.exceptions import InvalidSchema
 from .exceptions import (InvalidTokenError, AuthorizationNeededError,


### PR DESCRIPTION
Fixes a strange bug with fulltext predicate where the following snippet emits an error:

```fom.query(predicates.fulltext('document', 'anything')).submit()```

The error is something like this

```HTTPError: Got an HTTP error 400 ({"message":"[function fulltext(..)] unexpected value: should be a path  on line:1 col:59 in query '[[:d = fulltext(\"document\", \"any\")]]```

And is caused because 'document' is being quoted because of this if condition.