### PR TITLE
Remove pkg_resources import

### DIFF
--- a/prismic/connection.py
+++ b/prismic/connection.py
@@ -17,7 +17,6 @@ import requests
 import json
 import re
 import platform
-import pkg_resources
 from collections import OrderedDict
 from requests.exceptions import InvalidSchema
 from .exceptions import (InvalidTokenError, AuthorizationNeededError,


### PR DESCRIPTION
This commit simply removes pkg_resources import, as it's not needed anywhere in the module.