### PR TITLE
Fix bugs with cache and connection

### DIFF
--- a/prismic/api.py
+++ b/prismic/api.py
@@ -85,7 +85,7 @@ class Api(object):
 
         :return: the URL to redirect the user to
         """
-        main_document_id = get_json(token, request_handler=self.request_handler).get("mainDocument")
+        main_document_id = get_json(token, request_handler=self.request_handler, cache=self.cache).get("mainDocument")
         if main_document_id is None:
             return default_url
         response = self.form("everything").ref(token).query(predicates.at("document.id", main_document_id)).submit()

--- a/prismic/connection.py
+++ b/prismic/connection.py
@@ -66,7 +66,7 @@ def get_json(url, params=None, access_token=None, cache=None, ttl=None, request_
 
 
 def get_max_age(headers):
-    expire_header = headers["Cache-Control"]
+    expire_header = headers.get("Cache-Control")
     if expire_header is not None:
         m = re.match("max-age=(\d+)", expire_header)
         if m:


### PR DESCRIPTION
Hello! 

I've found some bugs related to cache, two bugs, to be precise:

- The preview_session method in API is not using cache object passed to API. This PR fixes that and now the preview_session uses the cache object normally.
- The endpoint related to preview_session method seems to not send a "Cache-Control" header. Which causes a KeyError exception when the connection module tries to get that header. This commit fixes the connection module to use `.get` method of the headers dict to get the Cache Control, which by defaults to None instead of raising a KeyError, which fixes the bug.

Today I'll release the website (which is an open source webapp at all) that will use this module to contact to prismic and caused to send all that PR's to this module. Do you like to see the result? :)

Thanks!