### PR TITLE
Fix header grabbing

### DIFF
--- a/prismic/connection.py
+++ b/prismic/connection.py
@@ -66,7 +66,7 @@ def get_json(url, params=None, access_token=None, cache=None, ttl=None, request_
 
 
 def get_max_age(headers):
-    expire_header = headers["Cache-Control"]
+    expire_header = headers.get("Cache-Control", None)
     if expire_header is not None:
         m = re.match("max-age=(\d+)", expire_header)
         if m:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for Prismic library"""
+
+from __future__ import (absolute_import, division, print_function, unicode_literals)
+
+import prismic
+from prismic import connection
+import unittest
+
+# logging.basicConfig(level=logging.DEBUG)
+# log = logging.getLogger(__name__)
+
+
+class ConnectionTestCase(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        """Teardown."""
+
+    def test_missing_header_key(self):
+        headers = {}
+        max_age = connection.get_max_age(headers)
+        self.assertEqual(max_age, None)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
@erwan 

I'm having a problem with preview tokens in a django app with the prismic python-kit.

```
File "/Users/peterconerly/src/2picmonkey/build/ve/lib/python2.7/site-packages/django/core/handlers/base.py" in get_response
  111.                     response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/Users/peterconerly/src/2picmonkey/py/frontend/frontend/views/__init__.py" in prismic_preview
  561.     url = prismic_helper.api.preview_session(token, prismic_helper.link_resolver, '/')
File "/Users/peterconerly/src/2picmonkey/build/ve/lib/python2.7/site-packages/prismic/api.py" in preview_session
  88.         main_document_id = get_json(token, request_handler=self.request_handler).get("mainDocument")
File "/Users/peterconerly/src/2picmonkey/build/ve/lib/python2.7/site-packages/prismic/connection.py" in get_json
  53.             expire = ttl or get_max_age(headers)
File "/Users/peterconerly/src/2picmonkey/build/ve/lib/python2.7/site-packages/prismic/connection.py" in get_max_age
  69.     expire_header = headers["Cache-Control"]
File "/Users/peterconerly/src/2picmonkey/build/ve/lib/python2.7/site-packages/requests/structures.py" in __getitem__
  54.         return self._store[key.lower()][1]
Exception Type: KeyError at /preview
Exception Value: 'cache-control'
```

This line: https://github.com/prismicio/python-kit/blob/686dc9a2df72f457838c72ea75c7d58bd0f856de/prismic/connection.py#L69

Should be 

```
expires_header = headers.get('Cache-Control', None)
```

And here's a PR for it