### PR TITLE
Shorten cache key lengths using md5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ cache.db
 node_modules/
 
 .eggs
+.envrc
+.direnv

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -9,21 +9,35 @@ import prismic
 from prismic import connection
 import unittest
 
-# logging.basicConfig(level=logging.DEBUG)
-# log = logging.getLogger(__name__)
-
 
 class ConnectionTestCase(unittest.TestCase):
-    def setUp(self):
-        pass
-
-    def tearDown(self):
-        """Teardown."""
 
     def test_missing_header_key(self):
         headers = {}
         max_age = connection.get_max_age(headers)
         self.assertEqual(max_age, None)
+
+    def test_long_key(self):
+        """
+        Test we can cache long keys
+
+        Some cache backends can't handle keys longer than 250 characters (like memcached)
+        """
+
+        def fake_request_handler(url):
+            return 200, '{}', {}
+
+        class ShortKeyCache(object):
+
+            def set(self, key, value, expires):
+                if len(key) > 250:
+                    raise Exception('key too long')
+
+            def get(self, key):
+                pass
+
+        long_key = 'http://unittest.prismic.io/' + ('a' * 300)
+        connection.get_json(long_key, request_handler=fake_request_handler, cache=ShortKeyCache(), ttl=5)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Some cache backends, like memcache, can't have keys longer than 250 characters.

Resolves issue #31 