### PR TITLE
Fix heading5 and heading6 tag

### DIFF
--- a/prismic/fragments.py
+++ b/prismic/fragments.py
@@ -589,6 +589,8 @@ class StructuredText(object):
             "heading2": Block.Heading,
             "heading3": Block.Heading,
             "heading4": Block.Heading,
+            "heading5": Block.Heading,
+            "heading6": Block.Heading,
             "paragraph": Block.Paragraph,
             "list-item": Block.ListItem,
             "o-list-item": lambda val: Block.ListItem(val, True),


### PR DESCRIPTION
@srenault There was issue with title field. When we are using title field having h5 or h6 tag, it throws exception in our app. So we debugged the issue and fixed it.