### PR TITLE
Fix file link

### DIFF
--- a/prismic/fragments.py
+++ b/prismic/fragments.py
@@ -36,7 +36,7 @@ class Fragment(object):
                 "Timestamp":      Fragment.Timestamp,
                 "StructuredText": StructuredText,
                 "Link.document":  Fragment.DocumentLink,
-                "Link.file":      Fragment.MediaLink,
+                "Link.file":      Fragment.FileLink,
                 "Link.web":       Fragment.WebLink,
                 "Link.image":     Fragment.ImageLink,
                 "Embed":          Fragment.Embed,


### PR DESCRIPTION
@srenault This is another issue I am reporting. When we are selecting document such as .pdf, .exe or any other file apart from images our app is throwing error. So we have debugged and fix the issue and hope to get it merge soon 