### PR TITLE
Add support for multi-languages

### DIFF
--- a/prismic/api.py
+++ b/prismic/api.py
@@ -140,14 +140,14 @@ class Api(object):
         if len(documents) > 0:
             return documents[0]
 
-    def get_by_uid(self, type, uid, ref=None, lang=None):
+    def get_by_uid(self, type, uid, ref=None, lang='*'):
         return self.query_first(predicates.at('my.' + type + '.uid', uid), ref, lang=lang)
 
-    def get_by_id(self, id, ref=None, lang=None):
+    def get_by_id(self, id, ref=None, lang='*'):
         return self.query_first(predicates.at('document.id', id), ref, lang=lang)
 
     def get_by_ids(self, ids, ref=None, page_size=None, page=None, orderings=None,
-                   after=None, fetch_links=None, lang=None):
+                   after=None, fetch_links=None, lang='*'):
         return self.query(
             predicates.in_('document.id', ids),
             ref,

--- a/prismic/api.py
+++ b/prismic/api.py
@@ -117,7 +117,7 @@ class Api(object):
             raise Exception("Bad form name %s, valid form names are: %s" % (name, ', '.join(self.forms)))
         return SearchForm(self.forms.get(name), self.access_token, self.cache, self.request_handler)
 
-    def query(self, q, ref=None, page_size=None, page=None, orderings=None, after=None, fetch_links=None):
+    def query(self, q, ref=None, page_size=None, page=None, orderings=None, after=None, fetch_links=None, lang=None):
         if ref is None:
             ref = self.get_master()
         form = self.form('everything').ref(ref)
@@ -131,20 +131,23 @@ class Api(object):
             form.after(after)
         if fetch_links is not None:
             form.fetch_links(fetch_links)
+        if lang is not None:
+            form.lang(lang)
         return form.query(q).submit()
 
-    def query_first(self, q, ref=None):
-        documents = self.query(q, ref, page_size=1, page=1).documents
+    def query_first(self, q, ref=None, lang=None):
+        documents = self.query(q, ref, page_size=1, page=1, lang=lang).documents
         if len(documents) > 0:
             return documents[0]
 
-    def get_by_uid(self, type, uid, ref=None):
-        return self.query_first(predicates.at('my.' + type + '.uid', uid), ref)
+    def get_by_uid(self, type, uid, ref=None, lang=None):
+        return self.query_first(predicates.at('my.' + type + '.uid', uid), ref, lang=lang)
 
-    def get_by_id(self, id, ref=None):
-        return self.query_first(predicates.at('document.id', id), ref)
+    def get_by_id(self, id, ref=None, lang=None):
+        return self.query_first(predicates.at('document.id', id), ref, lang=lang)
 
-    def get_by_ids(self, ids, ref=None, page_size=None, page=None, orderings=None, after=None, fetch_links=None):
+    def get_by_ids(self, ids, ref=None, page_size=None, page=None, orderings=None,
+                   after=None, fetch_links=None, lang=None):
         return self.query(
             predicates.in_('document.id', ids),
             ref,
@@ -152,11 +155,12 @@ class Api(object):
             page=page,
             orderings=orderings,
             after=after,
-            fetch_links=fetch_links
+            fetch_links=fetch_links,
+            lang=lang
         )
 
-    def get_single(self, type, ref=None):
-        return self.query_first(predicates.at('document.type', type), ref)
+    def get_single(self, type, ref=None, lang=None):
+        return self.query_first(predicates.at('document.type', type), ref, lang=lang)
 
 class Ref(object):
     """
@@ -315,6 +319,13 @@ class SearchForm(object):
         """Deprecated: use page_size instead
         """
         return self.page_size(nb_results)
+
+    def lang(self, lang):
+        """
+        Set query language eg. "fr-fr" for traditional French
+        :param lang: string
+        """
+        return self.set("lang", lang)
 
     def count(self):
         """Count the total number of results

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import setuptools
 
 setup(
     name='prismic',
-    version='1.5.0',
+    version='1.6.0',
     description='Prismic.io development kit',
     author='The Prismic.io Team',
     author_email='contact@prismic.io',

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -113,7 +113,7 @@ class DocTestCase(unittest.TestCase):
         url = doc.get_image('all.image').url
         self.assertEqual(
             url,
-            'https://prismic-io.s3.amazonaws.com/micro/e185bb021862c2c03a96bea92e170830908c39a3_thermometer.png')
+            'https://micro.cdn.prismic.io/micro/e185bb021862c2c03a96bea92e170830908c39a3_thermometer.png')
 
     def test_date(self):
         api = prismic.get('https://micro.prismic.io/api')

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -113,7 +113,7 @@ class DocTestCase(unittest.TestCase):
         url = doc.get_image('all.image').url
         self.assertEqual(
             url,
-            'https://micro.cdn.prismic.io/micro/e185bb021862c2c03a96bea92e170830908c39a3_thermometer.png')
+            'https://images.prismic.io/micro/e185bb021862c2c03a96bea92e170830908c39a3_thermometer.png?auto=compress,format')
 
     def test_date(self):
         api = prismic.get('https://micro.prismic.io/api')

--- a/tests/test_prismic.py
+++ b/tests/test_prismic.py
@@ -147,12 +147,26 @@ class ApiIntegrationTestCase(PrismicTestCase):
         doc = self.api.get_by_uid('all', 'all')
         self.assertEqual(doc.id, 'WHx-gSYAAMkyXYX_')
 
+    def test_get_by_uid_lang(self):
+        doc = self.api.get_by_uid('all', 'all', lang = 'en-us')
+        self.assertEqual(doc.id, 'WHx-gSYAAMkyXYX_')
+
     def test_get_by_id(self):
         doc = self.api.get_by_id('WHx-gSYAAMkyXYX_')
         self.assertEqual(doc.id, 'WHx-gSYAAMkyXYX_')
 
+    def test_get_by_id_lang(self):
+        doc = self.api.get_by_id('WHx-gSYAAMkyXYX_', lang='en-us')
+        self.assertEqual(doc.id, 'WHx-gSYAAMkyXYX_')
+
     def test_get_by_ids(self):
         result = self.api.get_by_ids(['WHx-gSYAAMkyXYX_', 'WHyJqyYAAHgyXbcj'])
+        ids = sorted([doc.id for doc in result.documents])
+        self.assertEqual(ids[0], 'WHx-gSYAAMkyXYX_')
+        self.assertEqual(ids[1], 'WHyJqyYAAHgyXbcj')
+
+    def test_get_by_ids_lang(self):
+        result = self.api.get_by_ids(['WHx-gSYAAMkyXYX_', 'WHyJqyYAAHgyXbcj'], lang="en-us")
         ids = sorted([doc.id for doc in result.documents])
         self.assertEqual(ids[0], 'WHx-gSYAAMkyXYX_')
         self.assertEqual(ids[1], 'WHyJqyYAAHgyXbcj')


### PR DESCRIPTION
Adds the suggested changes to #40 and resolves conflicts
>For get_by_uid, get_by_id, get_by_ids, the default language should be * (meaning we search over all languages)

To test run `python setup.py test`